### PR TITLE
 feat(settings-page): implement Settings module with System Integrations & MVVM architecture

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -23,8 +23,9 @@ namespace StreamBoard
         private void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<SettingsStorage>();
-            services.AddTransient<SettingsViewModel>();
+            services.AddSingleton<StartupService>();
 
+            services.AddTransient<SettingsViewModel>();
         }
 
         protected override void OnStartup(StartupEventArgs e)

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,6 +1,8 @@
-﻿using System.Configuration;
-using System.Data;
-using System.Windows;
+﻿using System.Windows;
+using Microsoft.Extensions.DependencyInjection;
+using StreamBoard.Features.Settings.Services;
+using StreamBoard.Features.Settings.ViewModels;
+using Wpf.Ui.Appearance;
 
 namespace StreamBoard
 {
@@ -9,6 +11,32 @@ namespace StreamBoard
     /// </summary>
     public partial class App : Application
     {
+        public static IServiceProvider ServiceProvider { get; private set; } = null!;
+
+        public App()
+        {
+            var services = new ServiceCollection();
+            ConfigureServices(services);
+            ServiceProvider = services.BuildServiceProvider();
+        }
+
+        private void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<SettingsStorage>();
+            services.AddTransient<SettingsViewModel>();
+
+        }
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            var storage = ServiceProvider.GetRequiredService<SettingsStorage>();
+
+            ApplicationThemeManager.Apply(
+                storage.Current.Theme == "Dark" ? ApplicationTheme.Dark : ApplicationTheme.Light
+            );
+        }
     }
 
 }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -24,6 +24,7 @@ namespace StreamBoard
         {
             services.AddSingleton<SettingsStorage>();
             services.AddSingleton<StartupService>();
+            services.AddSingleton<PrivilegeService>();
 
             services.AddTransient<SettingsViewModel>();
         }
@@ -33,10 +34,19 @@ namespace StreamBoard
             base.OnStartup(e);
 
             var storage = ServiceProvider.GetRequiredService<SettingsStorage>();
+            var privilegeService = ServiceProvider.GetRequiredService<PrivilegeService>();
 
             ApplicationThemeManager.Apply(
                 storage.Current.Theme == "Dark" ? ApplicationTheme.Dark : ApplicationTheme.Light
             );
+
+            if (storage.Current.RunAsAdmin && !privilegeService.IsRunAsAdmin())
+            {
+                privilegeService.RestartAsAdmin();
+
+                Application.Current.Shutdown();
+                return;
+            }
         }
     }
 

--- a/Components/Cards/CardWithToggleSwitch.xaml
+++ b/Components/Cards/CardWithToggleSwitch.xaml
@@ -1,0 +1,46 @@
+﻿<UserControl x:Class="StreamBoard.Components.Cards.CardWithToggleSwitch"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             x:Name="Root">
+    <ui:CardControl>
+        <ui:CardControl.Header>
+            <StackPanel>
+                <TextBlock Text="{Binding Title, ElementName=Root}" 
+                           FontSize="18" 
+                           FontWeight="SemiBold" />
+
+                <TextBlock Text="{Binding Description, ElementName=Root}" 
+                           FontSize="14" 
+                           FontWeight="Regular"
+                           Foreground="{DynamicResource TextFillColorSecondaryBrush}" 
+                           TextWrapping="Wrap"/>
+            </StackPanel>
+        </ui:CardControl.Header>
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock VerticalAlignment="Center">
+                <TextBlock.Style>
+                    <Style TargetType="TextBlock" BasedOn="{StaticResource BodyTextBlockStyle}">
+                        <Setter Property="Text" Value="{Binding ToggleOffText, ElementName=Root}" />
+
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsChecked, ElementName=Root}" Value="True">
+                                <Setter Property="Text" Value="{Binding ToggleOnText, ElementName=Root}" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </TextBlock.Style>
+            </TextBlock>
+
+            <ui:ToggleSwitch Grid.Column="1"
+                             IsChecked="{Binding IsChecked, ElementName=Root, Mode=TwoWay}"
+                             Margin="10,0,0,0" />
+        </Grid>
+    </ui:CardControl>
+</UserControl>

--- a/Components/Cards/CardWithToggleSwitch.xaml.cs
+++ b/Components/Cards/CardWithToggleSwitch.xaml.cs
@@ -1,0 +1,55 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace StreamBoard.Components.Cards
+{
+    public partial class CardWithToggleSwitch : UserControl
+    {
+        public CardWithToggleSwitch()
+        {
+            InitializeComponent();
+            this.DataContext = this;
+        }
+
+        public string Title
+        {
+            get { return (string)GetValue(TitleProperty); }
+            set { SetValue(TitleProperty, value); }
+        }
+        public static readonly DependencyProperty TitleProperty =
+            DependencyProperty.Register("Title", typeof(string), typeof(CardWithToggleSwitch), new PropertyMetadata("Title"));
+
+        public string Description
+        {
+            get { return (string)GetValue(DescriptionProperty); }
+            set { SetValue(DescriptionProperty, value); }
+        }
+        public static readonly DependencyProperty DescriptionProperty =
+            DependencyProperty.Register("Description", typeof(string), typeof(CardWithToggleSwitch), new PropertyMetadata("Description goes here"));
+
+        public string ToggleOffText
+        {
+            get { return (string)GetValue(ToggleOffTextProperty); }
+            set { SetValue(ToggleOffTextProperty, value); }
+        }
+        public static readonly DependencyProperty ToggleOffTextProperty =
+            DependencyProperty.Register("ToggleOffText", typeof(string), typeof(CardWithToggleSwitch), new PropertyMetadata("Off"));
+
+        public string ToggleOnText
+        {
+            get { return (string)GetValue(ToggleOnTextProperty); }
+            set { SetValue(ToggleOnTextProperty, value); }
+        }
+        public static readonly DependencyProperty ToggleOnTextProperty =
+            DependencyProperty.Register("ToggleOnText", typeof(string), typeof(CardWithToggleSwitch), new PropertyMetadata("On"));
+
+        public bool IsChecked
+        {
+            get { return (bool)GetValue(IsCheckedProperty); }
+            set { SetValue(IsCheckedProperty, value); }
+        }
+        public static readonly DependencyProperty IsCheckedProperty =
+            DependencyProperty.Register("IsChecked", typeof(bool), typeof(CardWithToggleSwitch),
+                new FrameworkPropertyMetadata(false, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+    }
+}

--- a/Components/Cards/CardWithToggleSwitch.xaml.cs
+++ b/Components/Cards/CardWithToggleSwitch.xaml.cs
@@ -8,7 +8,6 @@ namespace StreamBoard.Components.Cards
         public CardWithToggleSwitch()
         {
             InitializeComponent();
-            this.DataContext = this;
         }
 
         public string Title

--- a/Components/Navigation/MainNavView.xaml
+++ b/Components/Navigation/MainNavView.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl x:Class="StreamBoard.Components.Navigation.MainNavView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:StreamBoard.Components.Navigation"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             mc:Ignorable="d" 
+             d:DesignHeight="450" d:DesignWidth="800">
+
+    <ui:NavigationView x:Name="RootNavigation"
+                       PaneDisplayMode="Left"
+                       IsBackButtonVisible="Collapsed"
+                       IsPaneToggleVisible="True"
+                       IsTopSeparatorVisible="False"
+                       IsFooterSeparatorVisible="False"
+                       OpenPaneLength="250"
+                       FrameMargin="0">
+        <ui:NavigationView.MenuItems>
+            <ui:NavigationViewItem Content="Home"
+                                   Icon="{ui:SymbolIcon Home24}" 
+                                   Tag="home" />
+
+            <ui:NavigationViewItemSeparator />
+        </ui:NavigationView.MenuItems>
+
+        <ui:NavigationView.FooterMenuItems>
+            <ui:NavigationViewItemSeparator />
+            
+            <ui:NavigationViewItem Content="Settings" 
+                                   Icon="{ui:SymbolIcon Settings24}" 
+                                   Tag="settings" />
+        </ui:NavigationView.FooterMenuItems>
+    </ui:NavigationView>
+</UserControl>

--- a/Components/Navigation/MainNavView.xaml
+++ b/Components/Navigation/MainNavView.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:StreamBoard.Components.Navigation"
+             xmlns:settings="clr-namespace:StreamBoard.Features.Settings.Pages"
              xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
@@ -29,7 +30,7 @@
             
             <ui:NavigationViewItem Content="Settings" 
                                    Icon="{ui:SymbolIcon Settings24}" 
-                                   Tag="settings" />
+                                   TargetPageType="{x:Type settings:SettingsPage}" />
         </ui:NavigationView.FooterMenuItems>
     </ui:NavigationView>
 </UserControl>

--- a/Components/Navigation/MainNavView.xaml.cs
+++ b/Components/Navigation/MainNavView.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace StreamBoard.Components.Navigation
+{
+    /// <summary>
+    /// Interaction logic for MainNavView.xaml
+    /// </summary>
+    public partial class MainNavView : UserControl
+    {
+        public MainNavView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Components/Tray/TrayIcon.xaml
+++ b/Components/Tray/TrayIcon.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="StreamBoard.Components.Tray.TrayIconView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+             xmlns:tb="http://www.hardcodet.net/taskbar">
+
+    <Grid>
+        <tb:TaskbarIcon x:Name="NotifyIcon" 
+                        ToolTipText="StreamBoard" 
+                        IconSource="pack://application:,,,/StreamBoard;component/Assets/logo.ico" >
+
+            <tb:TaskbarIcon.ContextMenu>
+                <ContextMenu>
+                    <ui:MenuItem Header="Open" Click="OpenMenuItem_Click"/>
+                    <Separator />
+                    <ui:MenuItem Header="Exit" Click="ExitMenuItem_Click"/>
+                </ContextMenu>
+            </tb:TaskbarIcon.ContextMenu>
+
+        </tb:TaskbarIcon>
+    </Grid>
+</UserControl>

--- a/Components/Tray/TrayIcon.xaml.cs
+++ b/Components/Tray/TrayIcon.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+
+namespace StreamBoard.Components.Tray
+{
+    public partial class TrayIconView : UserControl
+    {
+        public TrayIconView()
+        {
+            InitializeComponent();
+        }
+
+        private void OpenMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            var mainWindow = Application.Current.MainWindow;
+            if (mainWindow != null)
+            {
+                mainWindow.Show();
+                mainWindow.WindowState = WindowState.Normal;
+                mainWindow.Activate();
+            }
+        }
+
+        private void ExitMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            Application.Current.Shutdown();
+        }
+    }
+}

--- a/Core/ObservableObject.cs
+++ b/Core/ObservableObject.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace StreamBoard.Core
+{
+    public class ObservableObject : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/Features/Settings/Components/PrivilegeStatusInfo.xaml
+++ b/Features/Settings/Components/PrivilegeStatusInfo.xaml
@@ -1,0 +1,41 @@
+﻿<UserControl x:Class="StreamBoard.Features.Settings.Components.PrivilegeStatusInfo"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    
+    <StackPanel Orientation="Horizontal" Margin="8,-8,0,12">
+        <TextBlock FontSize="12" VerticalAlignment="Center">
+            <TextBlock.Style>
+                <Style TargetType="TextBlock">
+                    <Setter Property="Text" Value="Current session is running with standard user privileges." />
+                    <Setter Property="Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsRunAsAdmin}" Value="True">
+                            <Setter Property="Text" Value="Current session is running with Administrator privileges." />
+                            <Setter Property="Foreground" Value="{DynamicResource SystemFillColorSuccessBrush}" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </TextBlock.Style>
+        </TextBlock>
+
+        <ui:Button Content="Restart now"
+                   Icon="ArrowCounterclockwise24"
+                   Appearance="Transparent"
+                   Padding="4,0"
+                   Margin="8,0,0,0"
+                   FontSize="12"
+                   Command="{Binding RestartAsAdminCommand}">
+            <ui:Button.Style>
+                <Style TargetType="{x:Type ui:Button}" BasedOn="{StaticResource {x:Type ui:Button}}">
+                    <Setter Property="Visibility" Value="Visible" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsRunAsAdmin}" Value="True">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ui:Button.Style>
+        </ui:Button>
+    </StackPanel>
+</UserControl>

--- a/Features/Settings/Components/PrivilegeStatusInfo.xaml.cs
+++ b/Features/Settings/Components/PrivilegeStatusInfo.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace StreamBoard.Features.Settings.Components
+{
+    /// <summary>
+    /// Interaction logic for PrivilegeStatusInfo.xaml
+    /// </summary>
+    public partial class PrivilegeStatusInfo : UserControl
+    {
+        public PrivilegeStatusInfo()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Features/Settings/Models/SettingsModel.cs
+++ b/Features/Settings/Models/SettingsModel.cs
@@ -1,0 +1,12 @@
+﻿namespace StreamBoard.Features.Settings.Models
+{
+    public class SettingsModel
+    {       
+        public bool MinimizeToTray { get; set; } = false;
+        public bool StartMinimized { get; set; } = false;
+        public bool StartupWithWindows { get; set; } = false;
+        public bool RunAsAdmin { get; set; } = false;
+        public string Theme { get; set; } = "Dark";
+
+    }
+}

--- a/Features/Settings/Pages/SettingsPage.xaml
+++ b/Features/Settings/Pages/SettingsPage.xaml
@@ -24,13 +24,15 @@
                    Margin="0,0,0,12"
                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
         
-        <cards:CardWithToggleSwitch x:Name="MinimizeToTraySwitcher"
-                                    Title="Minimize to Tray"
+        <cards:CardWithToggleSwitch Title="Minimize to Tray"
                                     Description="Hide to system tray when minimized"
                                     IsChecked="{Binding MinimizeToTray, Mode=TwoWay}" />
+
+        <cards:CardWithToggleSwitch Title="Start minimized"
+                                    Description="Launch the app hidden in the background on startup"
+                                    IsChecked="{Binding StartMinimized, Mode=TwoWay}" />
         
-        <cards:CardWithToggleSwitch x:Name="ThemeSwitcher"
-                                    Title="Theme"
+        <cards:CardWithToggleSwitch Title="Theme"
                                     Description="Switch between light and dark appearance" 
                                     ToggleOffText="Light" 
                                     ToggleOnText="Dark"

--- a/Features/Settings/Pages/SettingsPage.xaml
+++ b/Features/Settings/Pages/SettingsPage.xaml
@@ -11,13 +11,24 @@
       Title="SettingsPage">
 
     <StackPanel Margin="16">
+        <StackPanel.Resources>
+            <Style TargetType="cards:CardWithToggleSwitch">
+                <Setter Property="Margin" Value="0,0,0,12"/>
+            </Style>
+        </StackPanel.Resources>
+
         <TextBlock Text="Settings" 
                    FontSize="20" 
                    FontWeight="SemiBold" 
                    LineHeight="28" 
                    Margin="0,0,0,12"
                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-
+        
+        <cards:CardWithToggleSwitch x:Name="MinimizeToTraySwitcher"
+                                    Title="Minimize to Tray"
+                                    Description="Hide to system tray when minimized"
+                                    IsChecked="{Binding MinimizeToTray, Mode=TwoWay}" />
+        
         <cards:CardWithToggleSwitch x:Name="ThemeSwitcher"
                                     Title="Theme"
                                     Description="Switch between light and dark appearance" 

--- a/Features/Settings/Pages/SettingsPage.xaml
+++ b/Features/Settings/Pages/SettingsPage.xaml
@@ -23,7 +23,7 @@
                    LineHeight="28" 
                    Margin="0,0,0,12"
                    Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
-        
+
         <cards:CardWithToggleSwitch Title="Minimize to Tray"
                                     Description="Hide to system tray when minimized"
                                     IsChecked="{Binding MinimizeToTray, Mode=TwoWay}" />
@@ -31,7 +31,11 @@
         <cards:CardWithToggleSwitch Title="Start minimized"
                                     Description="Launch the app hidden in the background on startup"
                                     IsChecked="{Binding StartMinimized, Mode=TwoWay}" />
-        
+
+        <cards:CardWithToggleSwitch Title="Startup with Windows"
+                                    Description="Launch StreamBoard automatically when Windows starts up"
+                                    IsChecked="{Binding StartupWithWindows, Mode=TwoWay}" />
+
         <cards:CardWithToggleSwitch Title="Theme"
                                     Description="Switch between light and dark appearance" 
                                     ToggleOffText="Light" 

--- a/Features/Settings/Pages/SettingsPage.xaml
+++ b/Features/Settings/Pages/SettingsPage.xaml
@@ -6,6 +6,7 @@
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       xmlns:local="clr-namespace:StreamBoard.Features.Settings.Pages"
       xmlns:cards="clr-namespace:StreamBoard.Components.Cards"
+      xmlns:components="clr-namespace:StreamBoard.Features.Settings.Components"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
       Title="SettingsPage">
@@ -35,6 +36,12 @@
         <cards:CardWithToggleSwitch Title="Startup with Windows"
                                     Description="Launch StreamBoard automatically when Windows starts up"
                                     IsChecked="{Binding StartupWithWindows, Mode=TwoWay}" />
+
+        <cards:CardWithToggleSwitch Title="Run as an administrator"
+                                    Description="Grant permission to intercept and block input from specific keyboards"
+                                    IsChecked="{Binding RunAsAdmin, Mode=TwoWay}" />
+
+        <components:PrivilegeStatusInfo />
 
         <cards:CardWithToggleSwitch Title="Theme"
                                     Description="Switch between light and dark appearance" 

--- a/Features/Settings/Pages/SettingsPage.xaml
+++ b/Features/Settings/Pages/SettingsPage.xaml
@@ -1,0 +1,20 @@
+﻿<Page x:Class="StreamBoard.Features.Settings.Pages.SettingsPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+      xmlns:local="clr-namespace:StreamBoard.Features.Settings.Pages"
+      mc:Ignorable="d" 
+      d:DesignHeight="450" d:DesignWidth="800"
+      Title="SettingsPage">
+
+    <StackPanel Margin="16">
+        <TextBlock Text="Settings" 
+                   FontSize="20" 
+                   FontWeight="SemiBold" 
+                   LineHeight="28" 
+                   Margin="0,0,0,12"
+                   Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+    </StackPanel>
+</Page>

--- a/Features/Settings/Pages/SettingsPage.xaml
+++ b/Features/Settings/Pages/SettingsPage.xaml
@@ -5,6 +5,7 @@
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       xmlns:local="clr-namespace:StreamBoard.Features.Settings.Pages"
+      xmlns:cards="clr-namespace:StreamBoard.Components.Cards"
       mc:Ignorable="d" 
       d:DesignHeight="450" d:DesignWidth="800"
       Title="SettingsPage">
@@ -15,6 +16,13 @@
                    FontWeight="SemiBold" 
                    LineHeight="28" 
                    Margin="0,0,0,12"
-                   Foreground="{DynamicResource TextFillColorPrimaryBrush}" />
+                   Foreground="{DynamicResource TextFillColorPrimaryBrush}"/>
+
+        <cards:CardWithToggleSwitch x:Name="ThemeSwitcher"
+                                    Title="Theme"
+                                    Description="Switch between light and dark appearance" 
+                                    ToggleOffText="Light" 
+                                    ToggleOnText="Dark"
+                                    IsChecked="{Binding IsDarkTheme, Mode=TwoWay}" />
     </StackPanel>
 </Page>

--- a/Features/Settings/Pages/SettingsPage.xaml.cs
+++ b/Features/Settings/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Controls;
+﻿using Microsoft.Extensions.DependencyInjection;
+using StreamBoard.Features.Settings.ViewModels;
+using System.Windows.Controls;
 
 namespace StreamBoard.Features.Settings.Pages
 {
@@ -10,6 +12,8 @@ namespace StreamBoard.Features.Settings.Pages
         public SettingsPage()
         {
             InitializeComponent();
+
+            this.DataContext = App.ServiceProvider.GetRequiredService<SettingsViewModel>();
         }
     }
 }

--- a/Features/Settings/Pages/SettingsPage.xaml.cs
+++ b/Features/Settings/Pages/SettingsPage.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace StreamBoard.Features.Settings.Pages
+{
+    /// <summary>
+    /// Interaction logic for SettingsPage.xaml
+    /// </summary>
+    public partial class SettingsPage : Page
+    {
+        public SettingsPage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Features/Settings/Services/PrivilegeService.cs
+++ b/Features/Settings/Services/PrivilegeService.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics;
+using System.Security.Principal;
+using System.Windows;
+
+namespace StreamBoard.Features.Settings.Services
+{
+    public class PrivilegeService
+    {
+        public bool IsRunAsAdmin()
+        {
+            using(WindowsIdentity identity = WindowsIdentity.GetCurrent())
+            {
+                WindowsPrincipal principal = new WindowsPrincipal(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+        }
+
+        public void RestartAsAdmin()
+        {
+            var exePath = Process.GetCurrentProcess().MainModule?.FileName;
+
+            if (string.IsNullOrEmpty(exePath)) return;
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = exePath,
+                UseShellExecute = true,
+                Verb = "runas"
+            };
+
+            try
+            {
+                Process.Start(startInfo);
+                Application.Current.Shutdown();
+            }
+            catch
+            {
+                Debug.WriteLine("User cancelled elevation request.");
+            }
+        }
+    }
+}

--- a/Features/Settings/Services/SettingsStorage.cs
+++ b/Features/Settings/Services/SettingsStorage.cs
@@ -1,0 +1,32 @@
+﻿using StreamBoard.Features.Settings.Models;
+using StreamBoard.Helpers;
+using System.IO;
+
+namespace StreamBoard.Features.Settings.Services
+{
+    public class SettingsStorage
+    {
+        public readonly string _filePath;
+
+        public SettingsModel Current { get; private set; } = new();
+
+        public SettingsStorage()
+        {
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            _filePath = Path.Combine(baseDirectory, "data", "settings.json");
+
+            Load();
+        }
+
+        public void Load()
+        {
+            Current = JsonHelper.Load<SettingsModel>(_filePath);
+        }
+
+        public void Save()
+        {
+            JsonHelper.Save(_filePath, Current);
+        }
+    }
+}

--- a/Features/Settings/Services/StartupService.cs
+++ b/Features/Settings/Services/StartupService.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Win32;
+using System.Diagnostics;
+
+namespace StreamBoard.Features.Settings.Services
+{
+    public class StartupService
+    {
+        private const string AppName = "StreamBoard";
+
+        public void SetStartup(bool enable)
+        {
+            try
+            {
+                string exePath = Process.GetCurrentProcess().MainModule?.FileName
+                    ?? AppDomain.CurrentDomain.BaseDirectory + AppName + ".exe";
+
+                using (RegistryKey key = Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Run", true)!)
+                {
+                    if (enable)
+                    {
+                        key.SetValue(AppName, $"\"{exePath}\"");
+                    }
+                    else
+                    {
+                        key.DeleteValue(AppName, false);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[StartupService] Error: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using StreamBoard.Core;
+﻿using Microsoft.Win32;
+using StreamBoard.Core;
 using StreamBoard.Features.Settings.Services;
 using Wpf.Ui.Appearance;
 
@@ -7,10 +8,12 @@ namespace StreamBoard.Features.Settings.ViewModels
     public class SettingsViewModel : ObservableObject
     {
         private readonly SettingsStorage _storage;
+        private readonly StartupService _startupService;
 
-        public SettingsViewModel(SettingsStorage storage)
+        public SettingsViewModel(SettingsStorage storage, StartupService startupService)
         {
             _storage = storage;
+            _startupService = startupService;
         }
 
         public bool IsDarkTheme
@@ -47,6 +50,21 @@ namespace StreamBoard.Features.Settings.ViewModels
                 if (_storage.Current.StartMinimized == value) return;
                 _storage.Current.StartMinimized = value;
                 _storage.Save();
+                OnPropertyChanged();
+            }
+        }
+
+        public bool StartupWithWindows
+        {
+            get => _storage.Current.StartupWithWindows;
+            set
+            {
+                if (_storage.Current.StartupWithWindows == value) return;
+                _storage.Current.StartupWithWindows = value;
+                _storage.Save();
+
+                _startupService.SetStartup(value);
+
                 OnPropertyChanged();
             }
         }

--- a/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -26,5 +26,17 @@ namespace StreamBoard.Features.Settings.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        public bool MinimizeToTray
+        {
+            get => _storage.Current.MinimizeToTray;
+            set
+            {
+                if (_storage.Current.MinimizeToTray == value) return;
+                _storage.Current.MinimizeToTray = value;
+                _storage.Save();
+                OnPropertyChanged();
+            }
+        }
     }
 }

--- a/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -38,5 +38,17 @@ namespace StreamBoard.Features.Settings.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        public bool StartMinimized
+        {
+            get => _storage.Current.StartMinimized;
+            set
+            {
+                if (_storage.Current.StartMinimized == value) return;
+                _storage.Current.StartMinimized = value;
+                _storage.Save();
+                OnPropertyChanged();
+            }
+        }
     }
 }

--- a/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Win32;
 using StreamBoard.Core;
 using StreamBoard.Features.Settings.Services;
+using System.Windows.Input;
 using Wpf.Ui.Appearance;
+using Wpf.Ui.Input;
 
 namespace StreamBoard.Features.Settings.ViewModels
 {
@@ -9,11 +11,13 @@ namespace StreamBoard.Features.Settings.ViewModels
     {
         private readonly SettingsStorage _storage;
         private readonly StartupService _startupService;
+        private readonly PrivilegeService _privilegeService;
 
-        public SettingsViewModel(SettingsStorage storage, StartupService startupService)
+        public SettingsViewModel(SettingsStorage storage, StartupService startupService, PrivilegeService privilegeService)
         {
             _storage = storage;
             _startupService = startupService;
+            _privilegeService = privilegeService;
         }
 
         public bool IsDarkTheme
@@ -68,5 +72,21 @@ namespace StreamBoard.Features.Settings.ViewModels
                 OnPropertyChanged();
             }
         }
+
+        public bool RunAsAdmin
+        {
+            get => _storage.Current.RunAsAdmin;
+            set
+            {
+                if (_storage.Current.RunAsAdmin == value) return;
+                _storage.Current.RunAsAdmin = value;
+                _storage.Save();
+                OnPropertyChanged();
+            }
+        }
+
+        public bool IsRunAsAdmin => _privilegeService.IsRunAsAdmin();
+
+        public ICommand RestartAsAdminCommand => new RelayCommand<object>(_ => _privilegeService.RestartAsAdmin());
     }
 }

--- a/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,30 @@
+﻿using StreamBoard.Core;
+using StreamBoard.Features.Settings.Services;
+using Wpf.Ui.Appearance;
+
+namespace StreamBoard.Features.Settings.ViewModels
+{
+    public class SettingsViewModel : ObservableObject
+    {
+        private readonly SettingsStorage _storage;
+
+        public SettingsViewModel(SettingsStorage storage)
+        {
+            _storage = storage;
+        }
+
+        public bool IsDarkTheme
+        {
+            get => _storage.Current.Theme == "Dark";
+            set
+            {
+                if (IsDarkTheme == value) return;
+                _storage.Current.Theme = value ? "Dark" : "Light";
+                _storage.Save();
+
+                ApplicationThemeManager.Apply(value ? ApplicationTheme.Dark : ApplicationTheme.Light);
+                OnPropertyChanged();
+            }
+        }
+    }
+}

--- a/Helpers/JsonHelper.cs
+++ b/Helpers/JsonHelper.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using System.Text.Json;
+
+namespace StreamBoard.Helpers
+{
+    public static class JsonHelper
+    {
+        private static readonly JsonSerializerOptions _options = new()
+        {
+            WriteIndented = true,
+        };
+
+        public static void Save<T>(string filePath, T data)
+        {
+            var dir = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            var json = JsonSerializer.Serialize(data, _options);
+            File.WriteAllText(filePath, json);
+        }
+
+        public static T Load<T>(String filePath) where T : new()
+        {
+            if (!File.Exists(filePath)) return new T();
+            try
+            {
+                string json = File.ReadAllText(filePath);
+                return JsonSerializer.Deserialize<T>(json) ?? new T();
+            }
+            catch
+            {
+                return new T();
+            }
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
         xmlns:titlebar="clr-namespace:StreamBoard.Components.TitleBar"
+        xmlns:navigation="clr-namespace:StreamBoard.Components.Navigation"
         mc:Ignorable="d"
         Title="StreamBoard" Height="600" Width="1000"
         WindowBackdropType="Mica"
@@ -18,5 +19,7 @@
         </Grid.RowDefinitions>
 
         <titlebar:MainTitleBar Grid.Row="0" />
+
+        <navigation:MainNavView Grid.Row="1"/>
     </Grid>
 </ui:FluentWindow>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -7,10 +7,11 @@
         xmlns:titlebar="clr-namespace:StreamBoard.Components.TitleBar"
         mc:Ignorable="d"
         Title="StreamBoard" Height="600" Width="1000"
+        WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen"
         ExtendsContentIntoTitleBar="True">
 
-    <Grid>
+    <Grid Background="Transparent">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -6,6 +6,7 @@
         xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
         xmlns:titlebar="clr-namespace:StreamBoard.Components.TitleBar"
         xmlns:navigation="clr-namespace:StreamBoard.Components.Navigation"
+        xmlns:tray="clr-namespace:StreamBoard.Components.Tray"
         mc:Ignorable="d"
         Title="StreamBoard" Height="600" Width="1000"
         WindowBackdropType="Mica"
@@ -17,7 +18,9 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-
+        
+        <tray:TrayIconView />
+        
         <titlebar:MainTitleBar Grid.Row="0" />
 
         <navigation:MainNavView Grid.Row="1"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -17,6 +17,8 @@ namespace StreamBoard
         public MainWindow()
         {
             InitializeComponent();
+
+            WindowBackdropType = Wpf.Ui.Controls.WindowBackdropType.Mica;
         }
     }
 }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -26,7 +26,16 @@ namespace StreamBoard
 
             _settings = App.ServiceProvider.GetRequiredService<SettingsStorage>();
 
+            Loaded += MainWindow_Loaded;
             StateChanged += MainWindow_StateChanged;
+        }
+
+        private void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (_settings.Current.StartMinimized)
+            {
+                WindowState = WindowState.Minimized;
+            }
         }
 
         private void MainWindow_StateChanged(object? sender, EventArgs e)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using Microsoft.Extensions.DependencyInjection;
+using StreamBoard.Features.Settings.Services;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -14,11 +16,25 @@ namespace StreamBoard
 {
     public partial class MainWindow : FluentWindow
     {
+        private readonly SettingsStorage _settings;
+
         public MainWindow()
         {
             InitializeComponent();
 
             WindowBackdropType = Wpf.Ui.Controls.WindowBackdropType.Mica;
+
+            _settings = App.ServiceProvider.GetRequiredService<SettingsStorage>();
+
+            StateChanged += MainWindow_StateChanged;
+        }
+
+        private void MainWindow_StateChanged(object? sender, EventArgs e)
+        {
+            if (_settings.Current.MinimizeToTray && WindowState == WindowState.Minimized)
+            {
+                Hide();
+            }
         }
     }
 }

--- a/StreamBoard.csproj
+++ b/StreamBoard.csproj
@@ -17,6 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
 		<PackageReference Include="WPF-UI" Version="4.2.0" />
 	</ItemGroup>

--- a/StreamBoard.csproj
+++ b/StreamBoard.csproj
@@ -17,7 +17,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
 		<PackageReference Include="WPF-UI" Version="4.2.0" />
 	</ItemGroup>
-
+	
 </Project>


### PR DESCRIPTION
## 📝 Description
This PR introduces a comprehensive **Settings** module for StreamBoard. It establishes the core MVVM architecture, sets up Dependency Injection, and implements critical system integrations including System Tray management, Windows Registry startup, and Administrator privilege handling.

## ✨ Key Features

### ⚙️ System Integrations
- **Minimize to Tray:** added logic to hide the window to the system tray on minimize.
- **Start Minimized:** option to launch the application silently in the tray.
- **Run on Startup:** implemented `StartupService` to manage Windows Registry keys for auto-launch.
- **Run as Administrator:** added a toggle to request admin privileges via application restart. Includes a visual status indicator and a "Restart now" button if privileges are missing.

### 🎨 UI & UX Improvements
- **Mica Backdrop:** applied Windows 11 Mica effect to the main window.
- **Theme Switching:** fully functional Light/Dark theme toggle with persistence.
- **Custom Components:** created reusable `CardWithToggleSwitch`.
- **Navigation:** implemented `MainNavView` and connected routing to the Settings page.

### 🏗 Architecture
- **MVVM Setup:** introduced `ObservableObject`.
- **Dependency Injection:** integrated `Microsoft.Extensions.DependencyInjection` in `App.xaml.cs`.
- **Persistence:** implemented `SettingsStorage` and `JsonHelper` to save/load user preferences to JSON.
- **Services:** created dedicated services to handle specific logic:
  - `StartupService` (registry management)
  - `PrivilegeService` (process elevation & restart)
  - `SettingsStorage` (data persistence)

## 🛠 Technical Details
- **Dependency Injection:** services are registered as `Singleton` (Storage, System services) and ViewModels as `Transient`.
- **System Tray:** implemented using `Hardcodet.NotifyIcon.Wpf` with a context menu for quick actions (Open/Exit).

## 📸 Screenshots
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/aba2590d-dc74-4679-9f14-1557f75e79b6" />
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/c0769479-dd71-47b3-b5a2-d7aa121d94ac" />
<img width="276" height="159" alt="image" src="https://github.com/user-attachments/assets/a47c6638-97fb-4e63-b76c-894ded1f30aa" />
