### PR TITLE
feat(settings): add startup page selection

### DIFF
--- a/Components/Navigation/MainNavView.xaml.cs
+++ b/Components/Navigation/MainNavView.xaml.cs
@@ -1,22 +1,15 @@
-﻿using StreamBoard.Features.Home.Pages;
+﻿using Microsoft.Extensions.DependencyInjection;
+using StreamBoard.Features.Home.Pages;
+using StreamBoard.Features.Settings.Pages;
+using StreamBoard.Features.Servers.Pages;
+using StreamBoard.Features.Decks.Views.Pages; 
+using StreamBoard.Features.Settings.Services;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace StreamBoard.Components.Navigation
 {
-    /// <summary>
-    /// Interaction logic for MainNavView.xaml
-    /// </summary>
     public partial class MainNavView : UserControl
     {
         public Wpf.Ui.Controls.NavigationView GetNavigation() => RootNavigation;
@@ -24,7 +17,6 @@ namespace StreamBoard.Components.Navigation
         public MainNavView()
         {
             InitializeComponent();
-
             Loaded += OnLoaded;
         }
 
@@ -32,7 +24,19 @@ namespace StreamBoard.Components.Navigation
         {
             Loaded -= OnLoaded;
             
-            RootNavigation.Navigate(typeof(HomePage));
+            var settings = App.ServiceProvider.GetRequiredService<SettingsStorage>();
+            var startupPage = settings.Current.StartupPage;
+
+            Type pageToNavigate = startupPage switch
+            {
+                "Grid Deck" => typeof(GridDeckPage),
+                "HTTP Server" => typeof(HttpServerPage),
+                "Settings" => typeof(SettingsPage),
+                _ => typeof(HomePage)
+            };
+
+            // Виконуємо перехід
+            RootNavigation.Navigate(pageToNavigate);
         }
     }
 }

--- a/Features/Settings/Models/SettingsModel.cs
+++ b/Features/Settings/Models/SettingsModel.cs
@@ -4,16 +4,22 @@ namespace StreamBoard.Features.Settings.Models
 {
     public class SettingsModel
     {
+        [JsonPropertyName("startup_page")]
+        public string StartupPage { get; set; } = "Home";
+        
         [JsonPropertyName("minimize_to_tray")]
         public bool MinimizeToTray { get; set; } = false;
+        
         [JsonPropertyName("start_minimized")]
         public bool StartMinimized { get; set; } = false;
+        
         [JsonPropertyName("startup_with_windows")]
         public bool StartupWithWindows { get; set; } = false;
+        
         [JsonPropertyName("run_as_admin")]
         public bool RunAsAdmin { get; set; } = false;
+
         [JsonPropertyName("theme")]
         public string Theme { get; set; } = "Dark";
-
     }
 }

--- a/Features/Settings/Pages/SettingsPage.xaml
+++ b/Features/Settings/Pages/SettingsPage.xaml
@@ -1,15 +1,11 @@
 ﻿<Page x:Class="StreamBoard.Features.Settings.Pages.SettingsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       xmlns:local="clr-namespace:StreamBoard.Features.Settings.Pages"
       xmlns:cards="clr-namespace:StreamBoard.Components.Cards"
       xmlns:controls="clr-namespace:StreamBoard.Components.Controls"
       xmlns:components="clr-namespace:StreamBoard.Features.Settings.Components"
-      mc:Ignorable="d" 
-      d:DesignHeight="450" d:DesignWidth="800"
       Title="SettingsPage">
 
     <StackPanel Margin="16">
@@ -20,6 +16,16 @@
         </StackPanel.Resources>
 
         <controls:PageTitle Text="Settings" />
+
+        <cards:CardControl Title="Startup page"
+                           Description="Choose which page to open when the app starts">
+            <cards:CardControl.ActionContent>
+                <ComboBox ItemsSource="{Binding AvailableStartupPages}"
+                          SelectedItem="{Binding StartupPage, Mode=TwoWay}"
+                          Width="150" 
+                          VerticalAlignment="Center"/>
+            </cards:CardControl.ActionContent>
+        </cards:CardControl>
         
         <cards:CardControl Title="Minimize to Tray"
                            Description="Hide to system tray when minimized">

--- a/Features/Settings/ViewModels/SettingsViewModel.cs
+++ b/Features/Settings/ViewModels/SettingsViewModel.cs
@@ -88,5 +88,25 @@ namespace StreamBoard.Features.Settings.ViewModels
         public bool IsRunAsAdmin => _privilegeService.IsRunAsAdmin();
 
         public ICommand RestartAsAdminCommand => new RelayCommand<object>(_ => _privilegeService.RestartAsAdmin());
+
+        public List<string> AvailableStartupPages { get; } = new()
+        {
+            "Home",
+            "Grid Deck",
+            "HTTP Server",
+            "Settings"
+        };
+
+        public string StartupPage
+        {
+            get => _storage.Current.StartupPage;
+            set
+            {
+                if (_storage.Current.StartupPage == value) return;
+                _storage.Current.StartupPage = value;
+                _storage.Save();
+                OnPropertyChanged();
+            }
+        }
     }
 }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:navigation="clr-namespace:StreamBoard.Components.Navigation"
         xmlns:tray="clr-namespace:StreamBoard.Components.Tray"
         mc:Ignorable="d"
-        Title="StreamBoard" Height="800" Width="1252"
+        Title="StreamBoard" Height="600" Width="1252"
         WindowBackdropType="Mica"
         WindowStartupLocation="CenterScreen"
         ExtendsContentIntoTitleBar="True">


### PR DESCRIPTION
## 📝 Description
This PR introduces a new setting that allows users to choose which page opens automatically when StreamBoard launches.

## ✨ Key Features
- **Startup Page Selection:** added a dropdown in the Settings page to select the default startup page (Home, Grid Deck, HTTP Server or Settings);
- **Dynamic Routing:** updated the main navigation component (`MainNavView`) to dynamically route the user on app load based on their saved preference;
- **Persistence:** integrated the new `startup_page` property into the `SettingsModel` for JSON persistence.