### PR TITLE
fix(core): release mutex before restarting as administrator

### DIFF
--- a/Client/pubspec.yaml
+++ b/Client/pubspec.yaml
@@ -2,7 +2,7 @@ name: streamtabula
 description: "StreamTabula Client Application."
 publish_to: "none"
 
-version: 0.1.1-beta.1+1
+version: 0.1.1-beta.2+1
 
 environment:
   sdk: ^3.10.7

--- a/Desktop/Core/AppStartup/AppInitializer.cs
+++ b/Desktop/Core/AppStartup/AppInitializer.cs
@@ -42,6 +42,13 @@ namespace StreamTabula.Core.AppStartup
             // Run as admin
             if (settingStorage.Current.RunAsAdmin && !privilegeService.IsRunAsAdmin())
             {
+                if (_mutex != null)
+                {
+                    _mutex.ReleaseMutex();
+                    _mutex.Dispose();
+                    _mutex = null;
+                }
+
                 privilegeService.RestartAsAdmin();
                 Application.Current.Shutdown();
                 return;

--- a/Desktop/StreamTabula.csproj
+++ b/Desktop/StreamTabula.csproj
@@ -10,7 +10,7 @@
 		<RootNamespace>StreamTabula</RootNamespace>
 		<ApplicationIcon>Assets\Images\logo.ico</ApplicationIcon>
 
-		<Version>0.1.1-beta.1</Version>
+		<Version>0.1.1-beta.2</Version>
 		<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
 
 		<RuntimeIdentifier>win-x86</RuntimeIdentifier>


### PR DESCRIPTION
Fix blocking of application restart during administrator elevation by forcefully releasing and closing the Mutex before calling restart.